### PR TITLE
Added support to mysql2 gem

### DIFF
--- a/lib/rmre/generator.rb
+++ b/lib/rmre/generator.rb
@@ -70,6 +70,7 @@ module Rmre
       fk = []
       case @connection_options[:adapter]
       when 'mysql'
+      when 'mysql2'
         fk = mysql_foreign_keys
       when 'postgresql'
         fk = psql_foreign_keys


### PR DESCRIPTION
I don't know why, but I just can't make it work with mysql gem, and with mysql2 it doesn't generate the FKs. Since mysql2 is better than mysql gem, I just made a simple edit so mysql2 works fine for me now.

Hope it helps someone.
