### PR TITLE
Update README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -16,7 +16,7 @@ Rmre gem is on the Rubygems and you can install it with
 
 Rmre is very simple to use:
 
-  rmre -a mysql -d my_database -u my_username -p my_password -o /path/where/models/will/be/created
+  rmre -a mysql2 -d my_database -u my_username -p my_password -o /path/where/models/will/be/created
 
 That's all! Of course there is standard help which you can print at any time:
 


### PR DESCRIPTION
If default mysql adapter is not present, it gives this error
Please install the mysql adapter: `gem install activerecord-mysql-adapter` (Could not find mysql (~> 2.8.1) amongst[...]
While it needs mysql gem to be installed, and not activerecord-mysql-adapter. Since mysql2 is better than mysql gem, this should be used by default.
